### PR TITLE
 add an example of marshalling using reflect

### DIFF
--- a/gtpv2/benchmarks_test.go
+++ b/gtpv2/benchmarks_test.go
@@ -1,0 +1,146 @@
+package gtpv2_test
+
+import (
+	"testing"
+
+	"github.com/wmnsk/go-gtp/gtpv2"
+	"github.com/wmnsk/go-gtp/gtpv2/ie"
+	"github.com/wmnsk/go-gtp/gtpv2/message"
+	"github.com/wmnsk/go-gtp/gtpv2/testutils"
+)
+
+var nbLoop = 1
+var debug = false
+
+func BenchmarkEchoRequestNormal(b *testing.B) {
+
+	b.Log("BenchmarkEchoRequestNormal")
+	msg := message.NewEchoRequest(0, ie.NewRecovery(0x80), ie.NewNodeFeatures(0x01))
+	i := 0
+
+	for i < nbLoop {
+		/*payload*/
+		_, err := msg.Marshal()
+		if err != nil {
+			b.Errorf("could not Marshal EchoRequest : %s", err)
+		}
+		i++
+	}
+
+}
+
+func BenchmarkEchoRequestReflect(b *testing.B) {
+	b.Log("BenchmarkEchoRequestReflect")
+	msg1 := message.NewEchoRequest(0, ie.NewRecovery(0x80), ie.NewNodeFeatures(0x01))
+	i := 0
+	for i < nbLoop {
+
+		Totlen1 := msg1.MarshalLen1(debug)
+		Payloadtmp := make([]byte, Totlen1)
+		err := msg1.MarshalTo1(Payloadtmp, int(Totlen1), debug)
+		if err != nil {
+			b.Errorf("could not Marshal EchoRequest : %s", err)
+		}
+
+		i++
+
+	}
+
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+func BenchmarkCreateSessionRequestNormal(b *testing.B) {
+
+	b.Log("BenchmarkCreateSessionRequestNormal")
+
+	i := 0
+
+	msg := message.NewCreateSessionRequest(
+		testutils.TestBearerInfo.TEID, testutils.TestBearerInfo.Seq,
+		ie.NewIMSI("123451234567890"),
+		ie.NewMSISDN("123450123456789"),
+		ie.NewAccessPointName("some.apn.example"),
+		ie.NewFullyQualifiedTEID(gtpv2.IFTypeS11MMEGTPC, 0xffffffff, "1.1.1.1", ""),
+		ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPC, 0xffffffff, "1.1.1.2", "").WithInstance(1),
+		ie.NewPDNType(gtpv2.PDNTypeIPv4),
+		ie.NewAggregateMaximumBitRate(0x11111111, 0x22222222),
+		ie.NewIndicationFromOctets(0xa1, 0x08, 0x15, 0x10, 0x88, 0x81, 0x40),
+		ie.NewBearerContext(
+			ie.NewEPSBearerID(0x05),
+			ie.NewBearerQoS(1, 2, 1, 0xff, 0x1111111111, 0x2222222222, 0x1111111111, 0x2222222222),
+		),
+		ie.NewBearerContext(
+			ie.NewEPSBearerID(0x06),
+			ie.NewBearerQoS(1, 2, 1, 0xff, 0x1111111111, 0x2222222222, 0x1111111111, 0x2222222222),
+		),
+		ie.NewMobileEquipmentIdentity("123450123456789"),
+		ie.NewServingNetwork("123", "45"),
+		ie.NewPDNAddressAllocation("2.2.2.2"),
+		ie.NewAPNRestriction(gtpv2.APNRestrictionPublic1),
+		ie.NewUserLocationInformationStruct(
+			nil, nil, nil, ie.NewTAI("123", "45", 0x0001),
+			ie.NewECGI("123", "45", 0x00000101), nil, nil, nil,
+		),
+		ie.NewRATType(gtpv2.RATTypeEUTRAN),
+		ie.NewSelectionMode(gtpv2.SelectionModeMSorNetworkProvidedAPNSubscribedVerified),
+	)
+
+	for i < nbLoop {
+		/*payload*/
+		_, err := msg.Marshal()
+		if err != nil {
+			b.Errorf("could not Marshal CreateSessionRequest : %s", err)
+		}
+		i++
+	}
+
+}
+
+func BenchmarkCreateSessionRequestReflect(b *testing.B) {
+	b.Log("BenchmarkCreateSessionRequestReflect")
+	i := 0
+
+	msg1 := message.NewCreateSessionRequest(
+		testutils.TestBearerInfo.TEID, testutils.TestBearerInfo.Seq,
+		ie.NewIMSI("123451234567890"),
+		ie.NewMSISDN("123450123456789"),
+		ie.NewAccessPointName("some.apn.example"),
+		ie.NewFullyQualifiedTEID(gtpv2.IFTypeS11MMEGTPC, 0xffffffff, "1.1.1.1", ""),
+		ie.NewFullyQualifiedTEID(gtpv2.IFTypeS5S8PGWGTPC, 0xffffffff, "1.1.1.2", "").WithInstance(1),
+		ie.NewPDNType(gtpv2.PDNTypeIPv4),
+		ie.NewAggregateMaximumBitRate(0x11111111, 0x22222222),
+		ie.NewIndicationFromOctets(0xa1, 0x08, 0x15, 0x10, 0x88, 0x81, 0x40),
+		ie.NewBearerContext(
+			ie.NewEPSBearerID(0x05),
+			ie.NewBearerQoS(1, 2, 1, 0xff, 0x1111111111, 0x2222222222, 0x1111111111, 0x2222222222),
+		),
+		ie.NewBearerContext(
+			ie.NewEPSBearerID(0x06),
+			ie.NewBearerQoS(1, 2, 1, 0xff, 0x1111111111, 0x2222222222, 0x1111111111, 0x2222222222),
+		),
+		ie.NewMobileEquipmentIdentity("123450123456789"),
+		ie.NewServingNetwork("123", "45"),
+		ie.NewPDNAddressAllocation("2.2.2.2"),
+		ie.NewAPNRestriction(gtpv2.APNRestrictionPublic1),
+		ie.NewUserLocationInformationStruct(
+			nil, nil, nil, ie.NewTAI("123", "45", 0x0001),
+			ie.NewECGI("123", "45", 0x00000101), nil, nil, nil,
+		),
+		ie.NewRATType(gtpv2.RATTypeEUTRAN),
+		ie.NewSelectionMode(gtpv2.SelectionModeMSorNetworkProvidedAPNSubscribedVerified),
+	)
+	for i < nbLoop {
+
+		Totlen1 := msg1.MarshalLen1(debug)
+		Payloadtmp := make([]byte, Totlen1)
+		err := msg1.MarshalTo1(Payloadtmp, int(Totlen1), debug)
+		if err != nil {
+			b.Errorf("could not Marshal CreateSessionRequest : %s", err)
+		}
+
+		i++
+
+	}
+
+}

--- a/gtpv2/message/create-session-req.go
+++ b/gtpv2/message/create-session-req.go
@@ -1139,11 +1139,11 @@ func (c *CreateSessionRequest) TEID() uint32 {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-func (msg *CreateSessionRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) error {
+func (c *CreateSessionRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) error {
 
-	msg.Header.Payload = make([]byte, marshalLen-msg.Header.MarshalLen())
+	c.Header.Payload = make([]byte, marshalLen-c.Header.MarshalLen())
 
-	itemVal := reflect.ValueOf(*msg)
+	itemVal := reflect.ValueOf(*c)
 	var IElen, offset int64
 	for i := 1; i < itemVal.NumField(); i++ { //loop over fields in msg
 		fieldVal := itemVal.Field(i)        //get a field
@@ -1159,8 +1159,8 @@ func (msg *CreateSessionRequest) MarshalTo1(Payload []byte, marshalLen int, debu
 				MarshalLenResult := MarshalLenMethod.Call([]reflect.Value{}) //call method (i *IE) MarshalLen()
 				IElen = MarshalLenResult[0].Int()
 
-				MarshalToMethod := fieldVal.MethodByName("MarshalTo")                                                  //get method (i *IE) MarshalTo()
-				MarshalToResult := MarshalToMethod.Call([]reflect.Value{reflect.ValueOf(msg.Header.Payload[offset:])}) //call method (i *IE) MarshalTo()
+				MarshalToMethod := fieldVal.MethodByName("MarshalTo")                                                //get method (i *IE) MarshalTo()
+				MarshalToResult := MarshalToMethod.Call([]reflect.Value{reflect.ValueOf(c.Header.Payload[offset:])}) //call method (i *IE) MarshalTo()
 				if debug {
 					fmt.Println(i, " MarshalToResult[0] ==> ", MarshalToResult[0], "IElen = ", IElen)
 					fmt.Println(i, " ==> fieldVal1 ", fieldVal1.Kind(),
@@ -1177,10 +1177,10 @@ func (msg *CreateSessionRequest) MarshalTo1(Payload []byte, marshalLen int, debu
 		}
 	}
 	if debug {
-		fmt.Println("MarshalTo(msg *CreateSessionRequest) ==> msg.Header.Payload =  ", hex.Dump(msg.Header.Payload))
+		fmt.Println("MarshalTo(msg *CreateSessionRequest) ==> msg.Header.Payload =  ", hex.Dump(c.Header.Payload))
 	}
-	msg.Header.SetLength()
-	return msg.Header.MarshalTo(Payload)
+	c.Header.SetLength()
+	return c.Header.MarshalTo(Payload)
 
 }
 

--- a/gtpv2/message/create-session-req.go
+++ b/gtpv2/message/create-session-req.go
@@ -1184,11 +1184,11 @@ func (c *CreateSessionRequest) MarshalTo1(Payload []byte, marshalLen int, debug 
 
 }
 
-func (msg *CreateSessionRequest) MarshalLen1(debug bool) int64 {
+func (c *CreateSessionRequest) MarshalLen1(debug bool) int64 {
 	if debug {
-		fmt.Printf(" CreateSessionRequest ==> len(msg.Header.Payload) =  %d \n", len(msg.Header.Payload))
+		fmt.Printf(" CreateSessionRequest ==> len(msg.Header.Payload) =  %d \n", len(c.Header.Payload))
 	}
-	itemVal := reflect.ValueOf(*msg)
+	itemVal := reflect.ValueOf(*c)
 	var Totlen, IElen int64
 	for i := 0; i < itemVal.NumField(); i++ { //loop over fields in msg
 		fieldVal := itemVal.Field(i)        //get a field

--- a/gtpv2/message/create-session-req.go
+++ b/gtpv2/message/create-session-req.go
@@ -5,6 +5,10 @@
 package message
 
 import (
+	"encoding/hex"
+	"fmt"
+	"reflect"
+
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 )
 
@@ -1131,4 +1135,86 @@ func (c *CreateSessionRequest) MessageTypeName() string {
 // TEID returns the TEID in uint32.
 func (c *CreateSessionRequest) TEID() uint32 {
 	return c.Header.teid()
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+func (msg *CreateSessionRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) error {
+
+	msg.Header.Payload = make([]byte, marshalLen-msg.Header.MarshalLen())
+
+	itemVal := reflect.ValueOf(*msg)
+	var IElen, offset int64
+	for i := 1; i < itemVal.NumField(); i++ { //loop over fields in msg
+		fieldVal := itemVal.Field(i)        //get a field
+		if fieldVal.Kind() == reflect.Ptr { //check that it's a pointer
+			fieldVal1 := fieldVal.Elem() // This is only helpful if the field is not nil
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+			}
+			if fieldVal1.Kind() != reflect.Invalid { //check that Kind is valid
+				//fmt.Println(i, " ==> fieldVal1.Type().Name() ;", fieldVal1.Type().Name(), ";")
+
+				MarshalLenMethod := fieldVal.MethodByName("MarshalLen")      //get method (i *IE) MarshalLen()
+				MarshalLenResult := MarshalLenMethod.Call([]reflect.Value{}) //call method (i *IE) MarshalLen()
+				IElen = MarshalLenResult[0].Int()
+
+				MarshalToMethod := fieldVal.MethodByName("MarshalTo")                                                  //get method (i *IE) MarshalTo()
+				MarshalToResult := MarshalToMethod.Call([]reflect.Value{reflect.ValueOf(msg.Header.Payload[offset:])}) //call method (i *IE) MarshalTo()
+				if debug {
+					fmt.Println(i, " MarshalToResult[0] ==> ", MarshalToResult[0], "IElen = ", IElen)
+					fmt.Println(i, " ==> fieldVal1 ", fieldVal1.Kind(),
+						"  reflect.TypeOf(fieldVal1) =  ", fieldVal1.Type().Name())
+				}
+				offset += IElen //update offset
+
+			}
+			//fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+		} else {
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind())
+			}
+		}
+	}
+	if debug {
+		fmt.Println("MarshalTo(msg *CreateSessionRequest) ==> msg.Header.Payload =  ", hex.Dump(msg.Header.Payload))
+	}
+	msg.Header.SetLength()
+	return msg.Header.MarshalTo(Payload)
+
+}
+
+func (msg *CreateSessionRequest) MarshalLen1(debug bool) int64 {
+	if debug {
+		fmt.Printf(" CreateSessionRequest ==> len(msg.Header.Payload) =  %d \n", len(msg.Header.Payload))
+	}
+	itemVal := reflect.ValueOf(*msg)
+	var Totlen, IElen int64
+	for i := 0; i < itemVal.NumField(); i++ { //loop over fields in msg
+		fieldVal := itemVal.Field(i)        //get a field
+		if fieldVal.Kind() == reflect.Ptr { //check that it's a pointer
+			fieldVal1 := fieldVal.Elem() // This is only helpful if the field is not nil
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+			}
+			if fieldVal1.Kind() != reflect.Invalid { //check that Kind is valid
+				//fmt.Println(i, " ==> fieldVal1.Type().Name() ;", fieldVal1.Type().Name(), ";")
+
+				MarshalLenMethod := fieldVal.MethodByName("MarshalLen")      //get method (i *IE) MarshalLen()
+				MarshalLenResult := MarshalLenMethod.Call([]reflect.Value{}) //call method (i *IE) MarshalLen()
+				IElen = MarshalLenResult[0].Int()                            // get result from (i *IE) MarshalLen()
+				Totlen += IElen                                              //add MarshalLen to total length
+				if debug {
+					fmt.Println(i, "IElen = ", IElen)
+				}
+
+			}
+			//fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+		} else {
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind())
+			}
+		}
+	}
+	return Totlen
 }

--- a/gtpv2/message/echo-req.go
+++ b/gtpv2/message/echo-req.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 )
 
@@ -177,10 +178,9 @@ func (e *EchoRequest) TEID() uint32 {
 	return e.Header.teid()
 }
 
-
 //////////////////////////////////////////////////////////////////////////////
 
-func (msg *EchoRequest) MarshalTo1(Payload []byte, marshalLen int) error {
+func (msg *EchoRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) error {
 
 	msg.Header.Payload = make([]byte, marshalLen-msg.Header.MarshalLen())
 
@@ -190,7 +190,9 @@ func (msg *EchoRequest) MarshalTo1(Payload []byte, marshalLen int) error {
 		fieldVal := itemVal.Field(i)        //get a field
 		if fieldVal.Kind() == reflect.Ptr { //check that it's a pointer
 			fieldVal1 := fieldVal.Elem() // This is only helpful if the field is not nil
-			fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+			}
 			if fieldVal1.Kind() != reflect.Invalid { //check that Kind is valid
 				//fmt.Println(i, " ==> fieldVal1.Type().Name() ;", fieldVal1.Type().Name(), ";")
 
@@ -200,34 +202,42 @@ func (msg *EchoRequest) MarshalTo1(Payload []byte, marshalLen int) error {
 
 				MarshalToMethod := fieldVal.MethodByName("MarshalTo")                                                  //get method (i *IE) MarshalTo()
 				MarshalToResult := MarshalToMethod.Call([]reflect.Value{reflect.ValueOf(msg.Header.Payload[offset:])}) //call method (i *IE) MarshalTo()
-				fmt.Println(i, " MarshalToResult[0] ==> ", MarshalToResult[0], "IElen = ", IElen)
-				fmt.Println(i, " ==> fieldVal1 ", fieldVal1.Kind(),
-					"  reflect.TypeOf(fieldVal1) =  ", fieldVal1.Type().Name())
+				if debug {
+					fmt.Println(i, " MarshalToResult[0] ==> ", MarshalToResult[0], "IElen = ", IElen)
+					fmt.Println(i, " ==> fieldVal1 ", fieldVal1.Kind(),
+						"  reflect.TypeOf(fieldVal1) =  ", fieldVal1.Type().Name())
+				}
 				offset += IElen //update offset
 
 			}
 			//fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
 		} else {
-			fmt.Println(i, " ==> fieldVal ", fieldVal.Kind())
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind())
+			}
 		}
 	}
-	fmt.Println("MarshalTo(msg *EchoRequest) ==> msg.Header.Payload =  ", hex.Dump(msg.Header.Payload))
+	if debug {
+		fmt.Println("MarshalTo(msg *EchoRequest) ==> msg.Header.Payload =  ", hex.Dump(msg.Header.Payload))
+	}
 	msg.Header.SetLength()
 	return msg.Header.MarshalTo(Payload)
 
 }
 
-func (msg *EchoRequest) MarshalLen1() int64 {
-
-	fmt.Printf(" EchoRequest ==> len(msg.Header.Payload) =  %d \n", len(msg.Header.Payload))
-
+func (msg *EchoRequest) MarshalLen1(debug bool) int64 {
+	if debug {
+		fmt.Printf(" EchoRequest ==> len(msg.Header.Payload) =  %d \n", len(msg.Header.Payload))
+	}
 	itemVal := reflect.ValueOf(*msg)
 	var Totlen, IElen int64
 	for i := 0; i < itemVal.NumField(); i++ { //loop over fields in msg
 		fieldVal := itemVal.Field(i)        //get a field
 		if fieldVal.Kind() == reflect.Ptr { //check that it's a pointer
 			fieldVal1 := fieldVal.Elem() // This is only helpful if the field is not nil
-			fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
+			}
 			if fieldVal1.Kind() != reflect.Invalid { //check that Kind is valid
 				//fmt.Println(i, " ==> fieldVal1.Type().Name() ;", fieldVal1.Type().Name(), ";")
 
@@ -235,19 +245,16 @@ func (msg *EchoRequest) MarshalLen1() int64 {
 				MarshalLenResult := MarshalLenMethod.Call([]reflect.Value{}) //call method (i *IE) MarshalLen()
 				IElen = MarshalLenResult[0].Int()                            // get result from (i *IE) MarshalLen()
 				Totlen += IElen                                              //add MarshalLen to total length
-
-				fmt.Println(i, "IElen = ", IElen)
-
+				if debug {
+					fmt.Println(i, "IElen = ", IElen)
+				}
 			}
 			//fmt.Println(i, " ==> fieldVal ", fieldVal.Kind(), "   ", fieldVal1.Kind())
 		} else {
-			fmt.Println(i, " ==> fieldVal ", fieldVal.Kind())
+			if debug {
+				fmt.Println(i, " ==> fieldVal ", fieldVal.Kind())
+			}
 		}
 	}
 	return Totlen
 }
-
-
-
-
-

--- a/gtpv2/message/echo-req.go
+++ b/gtpv2/message/echo-req.go
@@ -225,11 +225,11 @@ func (e *EchoRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) err
 
 }
 
-func (msg *EchoRequest) MarshalLen1(debug bool) int64 {
+func (e *EchoRequest) MarshalLen1(debug bool) int64 {
 	if debug {
-		fmt.Printf(" EchoRequest ==> len(msg.Header.Payload) =  %d \n", len(msg.Header.Payload))
+		fmt.Printf(" EchoRequest ==> len(msg.Header.Payload) =  %d \n", len(e.Header.Payload))
 	}
-	itemVal := reflect.ValueOf(*msg)
+	itemVal := reflect.ValueOf(*e)
 	var Totlen, IElen int64
 	for i := 0; i < itemVal.NumField(); i++ { //loop over fields in msg
 		fieldVal := itemVal.Field(i)        //get a field

--- a/gtpv2/message/echo-req.go
+++ b/gtpv2/message/echo-req.go
@@ -180,11 +180,11 @@ func (e *EchoRequest) TEID() uint32 {
 
 //////////////////////////////////////////////////////////////////////////////
 
-func (msg *EchoRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) error {
+func (e *EchoRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) error {
 
-	msg.Header.Payload = make([]byte, marshalLen-msg.Header.MarshalLen())
+	e.Header.Payload = make([]byte, marshalLen-e.Header.MarshalLen())
 
-	itemVal := reflect.ValueOf(*msg)
+	itemVal := reflect.ValueOf(*e)
 	var IElen, offset int64
 	for i := 1; i < itemVal.NumField(); i++ { //loop over fields in msg
 		fieldVal := itemVal.Field(i)        //get a field
@@ -200,8 +200,8 @@ func (msg *EchoRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) e
 				MarshalLenResult := MarshalLenMethod.Call([]reflect.Value{}) //call method (i *IE) MarshalLen()
 				IElen = MarshalLenResult[0].Int()
 
-				MarshalToMethod := fieldVal.MethodByName("MarshalTo")                                                  //get method (i *IE) MarshalTo()
-				MarshalToResult := MarshalToMethod.Call([]reflect.Value{reflect.ValueOf(msg.Header.Payload[offset:])}) //call method (i *IE) MarshalTo()
+				MarshalToMethod := fieldVal.MethodByName("MarshalTo")                                                //get method (i *IE) MarshalTo()
+				MarshalToResult := MarshalToMethod.Call([]reflect.Value{reflect.ValueOf(e.Header.Payload[offset:])}) //call method (i *IE) MarshalTo()
 				if debug {
 					fmt.Println(i, " MarshalToResult[0] ==> ", MarshalToResult[0], "IElen = ", IElen)
 					fmt.Println(i, " ==> fieldVal1 ", fieldVal1.Kind(),
@@ -218,10 +218,10 @@ func (msg *EchoRequest) MarshalTo1(Payload []byte, marshalLen int, debug bool) e
 		}
 	}
 	if debug {
-		fmt.Println("MarshalTo(msg *EchoRequest) ==> msg.Header.Payload =  ", hex.Dump(msg.Header.Payload))
+		fmt.Println("MarshalTo(msg *EchoRequest) ==> msg.Header.Payload =  ", hex.Dump(e.Header.Payload))
 	}
-	msg.Header.SetLength()
-	return msg.Header.MarshalTo(Payload)
+	e.Header.SetLength()
+	return e.Header.MarshalTo(Payload)
 
 }
 


### PR DESCRIPTION
add MarshalTo() and MarshalLen() functions for GTPv2 echo request using reflect package.

reflection can be used in order to define Marshal functions once for all. here is an example with GTPv2 echo request message.  Message interface may be used to apply this to all messages types.